### PR TITLE
Add Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+
+sudo: false
+
+notifications:
+  email: false
+
+go:
+  - 1.5
+  - tip
+
+script:
+  - go test ./...
+  - go fmt ./...


### PR DESCRIPTION
This adds the config file for testing the app on CI. This will make
seeing that the tests are passing and the code is well formatted, as
well as other checks, easier because it is automated.

I chose to go with Travis CI because I like them as a company and think
the interface is nice.

Closes #4.
